### PR TITLE
Added Dumpert provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ s -p wikipedia rhinos
 * digg
 * dockerhub
 * duckduckgo
+* dumpert
 * github
 * gist
 * go

--- a/providers/dumpert/dumpert.go
+++ b/providers/dumpert/dumpert.go
@@ -1,0 +1,21 @@
+package dumpert
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/zquestz/s/providers"
+)
+
+func init() {
+	providers.AddProvider("dumpert", &DumpertProvider{})
+}
+
+// DumpertProvider adheres to the Provider interface.
+type DumpertProvider struct {
+}
+
+// BuildURI generates a search URL for dumpert.
+func (p *DumpertProvider) BuildURI(q string) string {
+	return fmt.Sprintf("https://www.dumpert.nl/search/ALL/%s/", url.QueryEscape(q))
+}

--- a/s.go
+++ b/s.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/zquestz/s/providers/digg"
 	_ "github.com/zquestz/s/providers/dockerhub"
 	_ "github.com/zquestz/s/providers/duckduckgo"
+	_ "github.com/zquestz/s/providers/dumpert"
 	_ "github.com/zquestz/s/providers/gist"
 	_ "github.com/zquestz/s/providers/github"
 	_ "github.com/zquestz/s/providers/go"


### PR DESCRIPTION
Dumpert is a dutch video platform for just funny video's. 

You can just ignore this if you do not think it's necessary to add stuff like this, but if you want to let `s` turn out to something like https://github.com/rg3/youtube-dl, you can! It's up to you  :)