### PR TITLE
Add support for getting search query from stdin

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -66,6 +67,11 @@ func performCommand(cmd *cobra.Command, args []string) error {
 
 	query := strings.Join(args, " ")
 
+	st, err := os.Stdin.Stat()
+	if err == nil && st.Mode()&os.ModeNamedPipe != 0 {
+		bytes, _ := ioutil.ReadAll(os.Stdin)
+		query = strings.TrimSpace(query + " " + string(bytes))
+	}
 	if query != "" {
 		err := providers.Search(binary, provider, query, verbose)
 		if err != nil {


### PR DESCRIPTION
This is useful if you want to pipe an error message from some app
directly to google, like:
```
$ someapp 2>&1 | s -
```
Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>