### PR TITLE
Consistent naming across all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ s -b w3m cats
 * [David Liu (tw4dl)](https://github.com/tw4dl/)
 * [Lex Broner (akb)](http://github.com/akb/)
 * [Diego Jara (djap96)](https://github.com/djap96/)
+* [Luvsandondov Lkhamsuren (lkhamsurenl)](https://github.com/lkhamsurenl/)
 
 #### License
 

--- a/providers/8tracks/8tracks.go
+++ b/providers/8tracks/8tracks.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("8tracks", &EightTracksProvider{})
+	providers.AddProvider("8tracks", &Provider{})
 }
 
-// EightTracksProvider adheres to the Provider interface.
-type EightTracksProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for 8tracks.
-func (p *EightTracksProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://8tracks.com/explore/%s", url.QueryEscape(q))
 }

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("amazon", &AmazonProvider{})
+	providers.AddProvider("amazon", &Provider{})
 }
 
-// AmazonProvider adheres to the Provider interface.
-type AmazonProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Amazon.
-func (p *AmazonProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.amazon.com/s/?keywords=%s", url.QueryEscape(q))
 }

--- a/providers/arxiv/arxiv.go
+++ b/providers/arxiv/arxiv.go
@@ -9,35 +9,33 @@ import (
 )
 
 func init() {
-	providers.AddProvider("arxiv", &ArxivProvider{})
+	providers.AddProvider("arxiv", &Provider{})
 }
 
-// ArxivProvider adheres to the Provider interface.
-type ArxivProvider struct {
-}
+type Provider struct {}
 
 // If the query contains more than 1 word, the format to binary logical
 // combination as follows:
 // "neural networks" -> "OP neural networks"
 // "convolutional neural networks" -> "OP networks OP convolutional neural"
 func formatWithOp(qs []string, op string) string {
-	var formatted_string string
+	var formattedString string
 
 	if len(qs) == 1 {
-		formatted_string = qs[0]
+		formattedString = qs[0]
 	} else {
-		formatted_string = fmt.Sprintf("%s %s", op, strings.Join(qs[:2], " "))
+		formattedString = fmt.Sprintf("%s %s", op, strings.Join(qs[:2], " "))
 	}
 	// Populate all the additional entries with OP in front of the current
 	// formatted string.
 	for i := 2; i < len(qs); i++ {
-		formatted_string = fmt.Sprintf("%s %s %s", op, qs[i], formatted_string)
+		formattedString = fmt.Sprintf("%s %s %s", op, qs[i], formattedString)
 	}
-	return formatted_string
+	return formattedString
 }
 
 // BuildURI generates a search URL for ArXiv.
-func (p *ArxivProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	// Separate query by "or".
 	queries := strings.Split(q, " or ")
 	results := make([]string, len(queries))

--- a/providers/arxiv/arxiv_test.go
+++ b/providers/arxiv/arxiv_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestBuildURI(t *testing.T) {
-	p := ArxivProvider{}
+	p := Provider{}
 	cases := []struct {
 		query, want string
 	}{

--- a/providers/atmospherejs/atmospherejs.go
+++ b/providers/atmospherejs/atmospherejs.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("atmospherejs", &AtmosphereJSProvider{})
+	providers.AddProvider("atmospherejs", &Provider{})
 }
 
-// AtmosphereJSProvider adheres to the Provider interface.
-type AtmosphereJSProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for AtmosphereJS.
-func (p *AtmosphereJSProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://atmospherejs.com/?q=%s", url.QueryEscape(q))
 }

--- a/providers/baidu/baidu.go
+++ b/providers/baidu/baidu.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("baidu", &BaiduProvider{})
+	providers.AddProvider("baidu", &Provider{})
 }
 
-// BaiduProvider adheres to the Provider interface.
-type BaiduProvider struct {
-}
+type Provider struct {}
 
-// BuildURI generates a search URL for Google.
-func (p *BaiduProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for Baidu.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.baidu.com/s?wd=%s", url.QueryEscape(q))
 }

--- a/providers/bandcamp/bandcamp.go
+++ b/providers/bandcamp/bandcamp.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("bandcamp", &BandcampProvider{})
+	providers.AddProvider("bandcamp", &Provider{})
 }
 
-// BandcampProvider adheres to the Provider interface.
-type BandcampProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Bandcamp.
-func (p *BandcampProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://bandcamp.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/bing/bing.go
+++ b/providers/bing/bing.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("bing", &BingProvider{})
+	providers.AddProvider("bing", &Provider{})
 }
 
-// BingProvider adheres to the Provider interface.
-type BingProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Bing.
-func (p *BingProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.bing.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/codepen/codepen.go
+++ b/providers/codepen/codepen.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("codepen", &CodePenProvider{})
+	providers.AddProvider("codepen", &Provider{})
 }
 
-//CodePenProvider adheres to the Provider interface.
-type CodePenProvider struct {
-}
+type Provider struct {}
 
 //BuildURI generates a search URL for CodePen.
-func (p *CodePenProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://codepen.io/search/pens?q=%s", url.QueryEscape(q))
 }

--- a/providers/coursera/coursera.go
+++ b/providers/coursera/coursera.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("coursera", &Coursera{})
+	providers.AddProvider("coursera", &Provider{})
 }
 
-// Coursera adheres to the Provider interface.
-type Coursera struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Coursera.
-func (p *Coursera) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.coursera.org/courses/?query=%s", url.QueryEscape(q))
 }

--- a/providers/crunchyroll/crunchyroll.go
+++ b/providers/crunchyroll/crunchyroll.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("crunchyroll", &CrunchyrollProvider{})
+	providers.AddProvider("crunchyroll", &Provider{})
 }
 
-// CrunchyrollProvider adheres to the Provider interface.
-type CrunchyrollProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Crunchyroll.
-func (p *CrunchyrollProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.crunchyroll.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/digg/digg.go
+++ b/providers/digg/digg.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("digg", &DiggProvider{})
+	providers.AddProvider("digg", &Provider{})
 }
 
-// DiggProvider adheres to the Provider interface.
-type DiggProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Digg.
-func (p *DiggProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://digg.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/dockerhub/dockerhub.go
+++ b/providers/dockerhub/dockerhub.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("dockerhub", &DockerHubProvider{})
+	providers.AddProvider("dockerhub", &Provider{})
 }
 
-// DockerHubProvider adheres to the Provider interface.
-type DockerHubProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Docker Hub.
-func (p *DockerHubProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://hub.docker.com/search/?q=%s", url.QueryEscape(q))
 }

--- a/providers/dribbble/dribbble.go
+++ b/providers/dribbble/dribbble.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("dribbble", &DribbbleProvider{})
+	providers.AddProvider("dribbble", &Provider{})
 }
 
-//DribbbleProvider adheres to the Provider interface.
-type DribbbleProvider struct {
-}
+type Provider struct {}
 
-//BuildURI generates a search URL for Dribbble.
-func (p *DribbbleProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for Dribbble.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://dribbble.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/duckduckgo/duckduckgo.go
+++ b/providers/duckduckgo/duckduckgo.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("duckduckgo", &DuckProvider{})
+	providers.AddProvider("duckduckgo", &Provider{})
 }
 
-// DuckProvider adheres to the Provider interface.
-type DuckProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for DuckDuckGo.
-func (p *DuckProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://duckduckgo.com/?q=%s", url.QueryEscape(q))
 }

--- a/providers/dumpert/dumpert.go
+++ b/providers/dumpert/dumpert.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("dumpert", &DumpertProvider{})
+	providers.AddProvider("dumpert", &Provider{})
 }
 
-// DumpertProvider adheres to the Provider interface.
-type DumpertProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for dumpert.
-func (p *DumpertProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.dumpert.nl/search/ALL/%s/", url.QueryEscape(q))
 }

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("facebook", &FacebookProvider{})
+	providers.AddProvider("facebook", &Provider{})
 }
 
-// FacebookProvider adheres to the Provider interface.
-type FacebookProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for facebook.
-func (p *FacebookProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.facebook.com/search/top/?q=%s", url.QueryEscape(q))
 }

--- a/providers/flickr/flickr.go
+++ b/providers/flickr/flickr.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("flickr", &FlickrProvider{})
+	providers.AddProvider("flickr", &Provider{})
 }
 
-// FlickrProvider adheres to the Provider interface.
-type FlickrProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for flickr.
-func (p *FlickrProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.flickr.com/search/?q=%s", url.QueryEscape(q))
 }

--- a/providers/flipkart/flipkart.go
+++ b/providers/flipkart/flipkart.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("flipkart", &FlipkartProvider{})
+	providers.AddProvider("flipkart", &Provider{})
 }
 
-// FlipkartProvider adheres to the Provider interface.
-type FlipkartProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Flipkart.
-func (p *FlipkartProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.flipkart.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/foursquare/foursquare.go
+++ b/providers/foursquare/foursquare.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("foursquare", &FoursquareProvider{})
+	providers.AddProvider("foursquare", &Provider{})
 }
 
-//FoursquareProvider adheres to the Provider interface.
-type FoursquareProvider struct {
-}
+type Provider struct {}
 
 //BuildURI generates a search URL for Foursquare.
-func (p *FoursquareProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://foursquare.com/explore?&q=%s", url.QueryEscape(q))
 }

--- a/providers/gist/gist.go
+++ b/providers/gist/gist.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("gist", &GistProvider{})
+	providers.AddProvider("gist", &Provider{})
 }
 
-// GistProvider adheres to the Provider interface.
-type GistProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Gist.
-func (p *GistProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://gist.github.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("github", &GitHubProvider{})
+	providers.AddProvider("github", &Provider{})
 }
 
-// GitHubProvider adheres to the Provider interface.
-type GitHubProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for GitHub.
-func (p *GitHubProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://github.com/search?utf8=✓&q=%s", url.QueryEscape(q))
 }

--- a/providers/gmail/gmail.go
+++ b/providers/gmail/gmail.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("gmail", &GmailProvider{})
+	providers.AddProvider("gmail", &Provider{})
 }
 
-// GmailProvider adheres to the Provider interface.
-type GmailProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for gmail.
-func (p *GmailProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://mail.google.com/mail/u/0/#search/%s", url.QueryEscape(q))
 }

--- a/providers/go/go.go
+++ b/providers/go/go.go
@@ -1,4 +1,4 @@
-package gopkg
+package golang
 
 import (
 	"fmt"
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("go", &GoProvider{})
+	providers.AddProvider("go", &Provider{})
 }
 
-// GoProvider adheres to the Provider interface.
-type GoProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Go.
-func (p *GoProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://golang.org/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/godoc/godoc.go
+++ b/providers/godoc/godoc.go
@@ -1,4 +1,4 @@
-package gopkg
+package godoc
 
 import (
 	"fmt"
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("godoc", &GoDocProvider{})
+	providers.AddProvider("godoc", &Provider{})
 }
 
-// GoDocProvider adheres to the Provider interface.
-type GoDocProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for GoDoc.
-func (p *GoDocProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://godoc.org/?q=%s", url.QueryEscape(q))
 }

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("google", &GoogleProvider{})
+	providers.AddProvider("google", &Provider{})
 }
 
-// GoogleProvider adheres to the Provider interface.
-type GoogleProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Google.
-func (p *GoogleProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.google.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/hackernews/hackernews.go
+++ b/providers/hackernews/hackernews.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("hackernews", &Hackernews{})
+	providers.AddProvider("hackernews", &Provider{})
 }
 
-// Hackernews adheres to the Provider interface.
-type Hackernews struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Hackernews.
-func (p *Hackernews) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://hn.algolia.com/?q=%s", url.QueryEscape(q))
 }

--- a/providers/ietf/ietf.go
+++ b/providers/ietf/ietf.go
@@ -8,15 +8,13 @@ import (
 )
 
 func init() {
-	providers.AddProvider("ietf", &IETFProvider{})
+	providers.AddProvider("ietf", &Provider{})
 }
 
-// IETF adheres to the Provider interface.
-type IETFProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for IETF.
-func (p *IETFProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://datatracker.ietf.org/doc/search/"+
 		"?name=%s&rfcs=on&activedrafts=on", url.QueryEscape(q))
 }

--- a/providers/ifttt/ifttt.go
+++ b/providers/ifttt/ifttt.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("ifttt", &IFTTTProvider{})
+	providers.AddProvider("ifttt", &Provider{})
 }
 
-// IFTTTProvider adheres to the Provider interface.
-type IFTTTProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for IFTTT.
-func (p *IFTTTProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.ifttt.com/recipes/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/imdb/imdb.go
+++ b/providers/imdb/imdb.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("imdb", &IMDBProvider{})
+	providers.AddProvider("imdb", &Provider{})
 }
 
-// IMDBProvider adheres to the Provider interface.
-type IMDBProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for IMDB.
-func (p *IMDBProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.imdb.com/find?q=%s", url.QueryEscape(q))
 }

--- a/providers/imgur/imgur.go
+++ b/providers/imgur/imgur.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("imgur", &Imgur{})
+	providers.AddProvider("imgur", &Provider{})
 }
 
-// Imgur adheres to the Provider interface.
-type Imgur struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Imgur.
-func (p *Imgur) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://imgur.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/kickasstorrents/kickasstorrents.go
+++ b/providers/kickasstorrents/kickasstorrents.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("kickasstorrents", &KickAssTorrentsProvider{})
+	providers.AddProvider("kickasstorrents", &Provider{})
 }
 
-// QuoraProvider adheres to the Provider interface.
-type KickAssTorrentsProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for KickAss Torrents.
-func (p *KickAssTorrentsProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://kat.cr/usearch/%s/", url.QueryEscape(q))
 }

--- a/providers/libgen/libgen.go
+++ b/providers/libgen/libgen.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("libgen", &Libgen{})
+	providers.AddProvider("libgen", &Provider{})
 }
 
-// Libgen adheres to the Provider interface.
-type Libgen struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Libgen.
-func (p *Libgen) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://gen.lib.rus.ec/search.php?req=%s", url.QueryEscape(q))
 }

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -8,15 +8,13 @@ import (
 )
 
 func init() {
-	providers.AddProvider("linkedin", &LinkedinProvider{})
+	providers.AddProvider("linkedin", &Provider{})
 }
 
-// LinkedinProvider adheres to the Provider interface.
-type LinkedinProvider struct {
-}
+type Provider struct {}
 
-// BuildURI generates a search URL for Linkedin Provider.
-func (p *LinkedinProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for Linkedin.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf(
 		"https://www.linkedin.com/vsearch/f?type=all&keywords=%s&search=Search",
 		url.QueryEscape(q))

--- a/providers/macports/macports.go
+++ b/providers/macports/macports.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("macports", &MacPortsProvider{})
+	providers.AddProvider("macports", &Provider{})
 }
 
-// MacPortsProvider adheres to the Provider interface.
-type MacPortsProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for macports.
-func (p *MacPortsProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.macports.org/ports.php?by=name&substr=%s", url.QueryEscape(q))
 }

--- a/providers/mdn/mdn.go
+++ b/providers/mdn/mdn.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("mdn", &MDNProvider{})
+	providers.AddProvider("mdn", &Provider{})
 }
 
-//MDNProvider adheres to the Provider interface.
-type MDNProvider struct {
-}
+type Provider struct {}
 
-//BuildURI generates a search URL for MDN.
-func (p *MDNProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for MDN.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://developer.mozilla.org/en-US/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/msdn/msdn.go
+++ b/providers/msdn/msdn.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("msdn", &MSDNProvider{})
+	providers.AddProvider("msdn", &Provider{})
 }
 
-//MSDNProvider adheres to the Provider interface.
-type MSDNProvider struct {
-}
+type Provider struct {}
 
-//BuildURI generates a search URL for MSDN.
-func (p *MSDNProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for MSDN.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://social.msdn.microsoft.com/Search/en-US?query=%s", url.QueryEscape(q))
 }

--- a/providers/nhaccuatui/nhaccuatui.go
+++ b/providers/nhaccuatui/nhaccuatui.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("nhaccuatui", &NhaccuatuiProvider{})
+	providers.AddProvider("nhaccuatui", &Provider{})
 }
 
-// NhaccuatuiProvider interface.
-type NhaccuatuiProvider struct {
-}
+type Provider struct {}
 
-// BuildURI generates a search URL for NhaccuatuiProvider.
-func (p *NhaccuatuiProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for Nhaccuatui.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.nhaccuatui.com/tim-kiem?q=%s", url.QueryEscape(q))
 }

--- a/providers/npm/npm.go
+++ b/providers/npm/npm.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("npm", &NpmProvider{})
+	providers.AddProvider("npm", &Provider{})
 }
 
-// NpmProvider adheres to the Provider interface.
-type NpmProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for npm.
-func (p *NpmProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.npmjs.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/npmsearch/npmsearch.go
+++ b/providers/npmsearch/npmsearch.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("npmsearch", &NpmSearchProvider{})
+	providers.AddProvider("npmsearch", &Provider{})
 }
 
-// NpmSearchProvider adheres to the Provider interface.
-type NpmSearchProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for npmsearch.
-func (p *NpmSearchProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://npmsearch.com/?q=%s", url.QueryEscape(q))
 }

--- a/providers/nvd/nvd.go
+++ b/providers/nvd/nvd.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("nvd", &NVDProvider{})
+	providers.AddProvider("nvd", &Provider{})
 }
 
-// NVDProvider adheres to the Provider interface.
-type NVDProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for the National Vulnerability Database.
-func (p *NVDProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://web.nvd.nist.gov/view/vuln/search-results?query=%s", url.QueryEscape(q))
 }

--- a/providers/packagist/packagist.go
+++ b/providers/packagist/packagist.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("packagist", &PackagistProvider{})
+	providers.AddProvider("packagist", &Provider{})
 }
 
-// PackagistProvider adheres to the Provider interface.
-type PackagistProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for packagist.
-func (p *PackagistProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://packagist.org/search/?q=%s", url.QueryEscape(q))
 }

--- a/providers/php/php.go
+++ b/providers/php/php.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("php", &PhpProvider{})
+	providers.AddProvider("php", &Provider{})
 }
 
-// PhpProvider adheres to the Provider interface.
-type PhpProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Php.
-func (p *PhpProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://php.net/%s", url.QueryEscape(q))
 }

--- a/providers/pinterest/pinterest.go
+++ b/providers/pinterest/pinterest.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("pinterest", &PinterestProvider{})
+	providers.AddProvider("pinterest", &Provider{})
 }
 
-// PinterestProvider adheres to the Provider interface.
-type PinterestProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Pinterest.
-func (p *PinterestProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.pinterest.com/search/pins/?q=%s", url.QueryEscape(q))
 }

--- a/providers/python/python.go
+++ b/providers/python/python.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("python", &PythonProvider{})
+	providers.AddProvider("python", &Provider{})
 }
 
-//PythonProvider adheres to the Provider interface.
-type PythonProvider struct {
-}
+type Provider struct {}
 
-//BuildURI generates a search URL for Python.
-func (p *PythonProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for Python.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.python.org/search/?q=%s", url.QueryEscape(q))
 }

--- a/providers/quora/quora.go
+++ b/providers/quora/quora.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("quora", &QuoraProvider{})
+	providers.AddProvider("quora", &Provider{})
 }
 
-// QuoraProvider adheres to the Provider interface.
-type QuoraProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Quora.
-func (p *QuoraProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.quora.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/reddit/reddit.go
+++ b/providers/reddit/reddit.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("reddit", &RedditProvider{})
+	providers.AddProvider("reddit", &Provider{})
 }
 
-// RedditProvider adheres to the Provider interface.
-type RedditProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Reddit.
-func (p *RedditProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.reddit.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/rubygems/rubygems.go
+++ b/providers/rubygems/rubygems.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("rubygems", &RubyGemsProvider{})
+	providers.AddProvider("rubygems", &Provider{})
 }
 
-// RubyGemsProvider adheres to the Provider interface.
-type RubyGemsProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for RubyGems.
-func (p *RubyGemsProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://rubygems.org/search?utf8=✓&query=%s", url.QueryEscape(q))
 }

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("soundcloud", &SoundCloudProvider{})
+	providers.AddProvider("soundcloud", &Provider{})
 }
 
-// SoundCloudProvider adheres to the Provider interface.
-type SoundCloudProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for SoundCloud.
-func (p *SoundCloudProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://soundcloud.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("spotify", &SpotifyProvider{})
+	providers.AddProvider("spotify", &Provider{})
 }
 
-// SpotifyProvider adheres to the Provider interface.
-type SpotifyProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for spotify.
-func (p *SpotifyProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://play.spotify.com/search/%s", url.QueryEscape(q))
 }

--- a/providers/stackoverflow/stackoverflow.go
+++ b/providers/stackoverflow/stackoverflow.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("stackoverflow", &StackOverflowProvider{})
+	providers.AddProvider("stackoverflow", &Provider{})
 }
 
-// StackOverflowProvider adheres to the Provider interface.
-type StackOverflowProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Stack Overflow.
-func (p *StackOverflowProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://stackoverflow.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("steam", &SteamProvider{})
+	providers.AddProvider("steam", &Provider{})
 }
 
-// SteamProvider adheres to the Provider interface.
-type SteamProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Steam.
-func (p *SteamProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://store.steampowered.com/search/?term=%s", url.QueryEscape(q))
 }

--- a/providers/taobao/taobao.go
+++ b/providers/taobao/taobao.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("taobao", &TaobaoProvider{})
+	providers.AddProvider("taobao", &Provider{})
 }
 
-// TaobaoProvider adheres to the Provider interface.
-type TaobaoProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Taobao.
-func (p *TaobaoProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://s.taobao.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/thepiratebay/thepiratebay.go
+++ b/providers/thepiratebay/thepiratebay.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("thepiratebay", &ThePirateBayProvider{})
+	providers.AddProvider("thepiratebay", &Provider{})
 }
 
-// QuoraProvider adheres to the Provider interface.
-type ThePirateBayProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for ThePirateBay.
-func (p *ThePirateBayProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://thepiratebay.se/search/%s", url.QueryEscape(q))
 }

--- a/providers/twitchtv/twitchtv.go
+++ b/providers/twitchtv/twitchtv.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("twitchtv", &Twitchtv{})
+	providers.AddProvider("twitchtv", &Provider{})
 }
 
-// Twitchtv adheres to the Provider interface.
-type Twitchtv struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Twitchtv.
-func (p *Twitchtv) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.twitch.tv/search?query=%s", url.QueryEscape(q))
 }

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("twitter", &TwitterProvider{})
+	providers.AddProvider("twitter", &Provider{})
 }
 
-// TwitterProvider adheres to the Provider interface.
-type TwitterProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Twitter.
-func (p *TwitterProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://twitter.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/unity3d/unity3d.go
+++ b/providers/unity3d/unity3d.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("unity3d", &Unity3DProvider{})
+	providers.AddProvider("unity3d", &Provider{})
 }
 
-//Unity3DProvider adheres to the Provider interface.
-type Unity3DProvider struct {
-}
+type Provider struct {}
 
-//BuildURI generates a search URL for Unity3D.
-func (p *Unity3DProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for Unity3D.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://unity3d.com/search?gq=%s", url.QueryEscape(q))
 }

--- a/providers/vimeo/vimeo.go
+++ b/providers/vimeo/vimeo.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("vimeo", &VimeoProvider{})
+	providers.AddProvider("vimeo", &Provider{})
 }
 
-//VimeoProvider adheres to the Provider interface.
-type VimeoProvider struct {
-}
+type Provider struct {}
 
-//BuildURI generates a search URL for Vimeo.
-func (p *VimeoProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for Vimeo.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://vimeo.com/search?q=%s", url.QueryEscape(q))
 }

--- a/providers/wikipedia/wikipedia.go
+++ b/providers/wikipedia/wikipedia.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("wikipedia", &WikiProvider{})
+	providers.AddProvider("wikipedia", &Provider{})
 }
 
-// WikiProvider adheres to the Provider interface.
-type WikiProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Wikipedia.
-func (p *WikiProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://en.wikipedia.org/wiki/Special:Search?search=%s", url.QueryEscape(q))
 }

--- a/providers/wolframalpha/wolframalpha.go
+++ b/providers/wolframalpha/wolframalpha.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("wolframalpha", &WolframAlphaProvider{})
+	providers.AddProvider("wolframalpha", &Provider{})
 }
 
-// WolframAlphaProvider adheres to the Provider interface.
-type WolframAlphaProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for WolframAlpha.
-func (p *WolframAlphaProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.wolframalpha.com/input/?i=%s", url.QueryEscape(q))
 }

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("yahoo", &YahooProvider{})
+	providers.AddProvider("yahoo", &Provider{})
 }
 
-// YahooProvider adheres to the Provider interface.
-type YahooProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for Yahoo.
-func (p *YahooProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://search.yahoo.com/search?p=%s", url.QueryEscape(q))
 }

--- a/providers/yandex/yandex.go
+++ b/providers/yandex/yandex.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("yandex", &YandexProvider{})
+	providers.AddProvider("yandex", &Provider{})
 }
 
-// YandexProvider adheres to the Provider interface.
-type YandexProvider struct {
-}
+type Provider struct {}
 
-// BuildURI generates a search URL for Google.
-func (p *YandexProvider) BuildURI(q string) string {
+// BuildURI generates a search URL for Yandex.
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.yandex.com/search/?text=%s", url.QueryEscape(q))
 }

--- a/providers/youtube/youtube.go
+++ b/providers/youtube/youtube.go
@@ -8,14 +8,12 @@ import (
 )
 
 func init() {
-	providers.AddProvider("youtube", &YouTubeProvider{})
+	providers.AddProvider("youtube", &Provider{})
 }
 
-// YouTubeProvider adheres to the Provider interface.
-type YouTubeProvider struct {
-}
+type Provider struct {}
 
 // BuildURI generates a search URL for YouTube.
-func (p *YouTubeProvider) BuildURI(q string) string {
+func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.youtube.com/results?search_query=%s", url.QueryEscape(q))
 }


### PR DESCRIPTION
When implementing new provider, naming should be consistent across all providers since all adheres to the Provider interface.