### PR TITLE
added upcloud.com support documentation search

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ s -b "chromium --incognito" conspiracy theories
 * twitchtv
 * twitter
 * unity3d
+* upcloud
 * vimeo
 * wikipedia
 * wolframalpha

--- a/providers/upcloud/upcloud.go
+++ b/providers/upcloud/upcloud.go
@@ -1,0 +1,20 @@
+package upcloud
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/zquestz/s/providers"
+)
+
+func init() {
+	providers.AddProvider("upcloud", &Provider{})
+}
+
+// Provider merely implements the Provider interface.
+type Provider struct{}
+
+// BuildURI generates a search URL for UpCloud.
+func (p *Provider) BuildURI(q string) string {
+	return fmt.Sprintf("https://www.upcloud.com/support/?s=%s", url.QueryEscape(q))
+}

--- a/s.go
+++ b/s.go
@@ -62,6 +62,7 @@ import (
 	_ "github.com/zquestz/s/providers/twitchtv"
 	_ "github.com/zquestz/s/providers/twitter"
 	_ "github.com/zquestz/s/providers/unity3d"
+	_ "github.com/zquestz/s/providers/upcloud"
 	_ "github.com/zquestz/s/providers/vimeo"
 	_ "github.com/zquestz/s/providers/wikipedia"
 	_ "github.com/zquestz/s/providers/wolframalpha"


### PR DESCRIPTION
We continuously write support documentation for developers who have their VMs on UpCloud. I believe they'd find this useful.