### PR TITLE
Auto binary update by Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+pkg
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-- 1.4.3
-- 1.5.3
-- tip
+  - 1.4.3
+  - 1.5.3
+  - tip
 env:
   global:
     - BUILD_GOARCH=amd64
@@ -11,12 +11,16 @@ env:
     - BUILD_GOOS=darwin
     - BUILD_GOOS=windows
 install:
-- go get golang.org/x/tools/cmd/vet
-- go get -v github.com/zquestz/s
+  - go get golang.org/x/tools/cmd/vet
+  - go get -v github.com/zquestz/s
 script:
-- go build
-- go fmt ./...
-- go vet ./...
-- go test -i -race ./...
-- go test -v -race ./...
-
+  - go build
+  - go fmt ./...
+  - go vet ./...
+  - go test -i -race ./...
+  - go test -v -race ./...
+after_script:
+  - if [ "$TRAVIS_GO_VERSION" = "1.5.3" ] && [ "$BUILD_GOOS" = "linux" ] && [ "$TRAVIS_TAG" != "" ]; then go get github.com/inconshreveable/mousetrap; fi
+  - if [ "$TRAVIS_GO_VERSION" = "1.5.3" ] && [ "$BUILD_GOOS" = "linux" ] && [ "$TRAVIS_TAG" != "" ]; then go get github.com/mitchellh/gox; fi
+  - if [ "$TRAVIS_GO_VERSION" = "1.5.3" ] && [ "$BUILD_GOOS" = "linux" ] && [ "$TRAVIS_TAG" != "" ]; then go get github.com/tcnksm/ghr; fi
+  - if [ "$TRAVIS_GO_VERSION" = "1.5.3" ] && [ "$BUILD_GOOS" = "linux" ] && [ "$TRAVIS_TAG" != "" ]; then make compile; ghr --username zquestz --token $GITHUB_TOKEN --replace $TRAVIS_TAG pkg/; fi

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
 APPNAME = s
+OSARCH = darwin/386 darwin/amd64 linux/386 linux/amd64 windows/386 windows/amd64
+DIRS = darwin_386 darwin_amd64 linux_386 linux_amd64 windows_386 windows_amd64
+OUTDIR = pkg
 
 all:
 	go build .
+
+compile:
+	gox -osarch="$(OSARCH)" -output "$(OUTDIR)/{{.OS}}_{{.Arch}}/s"
+	@for dir in $(DIRS) ; do \
+		(cd $(OUTDIR) && zip -q s_$$dir.zip -r $$dir) ;\
+		echo "make $(OUTDIR)/s_$$dir.zip" ;\
+	done
 
 install: all
 	go install .


### PR DESCRIPTION
This pull request is only my proposal of #73.

## Dependencies

- [gox](https://github.com/mitchellh/gox.git)
- [ghr](https://github.com/tcnksm/ghr.git)

gox is build for multi platform.
ghr is for release to the github releases page.

These commands are only used in the build and release process, not affects to the software core code.

## Build

The build process is only executed by gox, when we push the tag to the repository.
For example
```sh:
$ git tag -a v0.2.3 -m 'Release v0.2.3' 
$ git push origin v0.2.3
```
Currently, the binaries are build by linux / go 1.5.3. The target os are linux, osx, and windows, 32bit / 64bit both.

## Release

ghr releases the binaries to github releases page. You need to set `GITHUB_TOKEN` in environmental variables on Travis-CI's setting page.

