### PR TITLE
Provide provider filtering in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,19 +119,31 @@ To setup your own default configuration just create `~/.s/config`. The configura
 For more information about UCL visit:
 [https://github.com/vstakhov/libucl](https://github.com/vstakhov/libucl)
 
-This config sets your default provider to duckduckgo:
+Set your default provider to duckduckgo:
 ```
 provider: duckduckgo
 ```
 
+To only search a few providers:
+```
+whitelist: [google, amazon, wikipedia]
+```
+
+To exclude providers you don't need:
+```
+blacklist: [dumpert]
+```
+
 The following keys are supported:
 
+* blacklist (array of providers to exclude)
 * binary (binary to launch search URI)
 * cert (path to cert.pem for TLS)
 * key (path to key.pem for TLS)
 * port (server port)
 * provider (search provider)
 * verbose (display URL when opening)
+* whitelist (array of providers to include)
 
 ## Supported Providers
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,15 +11,17 @@ import (
 
 // Config stores all the application configuration.
 type Config struct {
-	Binary         string `json:"binary"`
-	Cert           string `json:"cert"`
-	DisplayVersion bool   `json:"-"`
-	Key            string `json:"key"`
-	ListProviders  bool   `json:"-"`
-	Port           int    `json:"port,string"`
-	Provider       string `json:"provider"`
-	ServerMode     bool   `json:"-"`
-	Verbose        bool   `json:"verbose,string"`
+	Blacklist      []string `json:"blacklist"`
+	Binary         string   `json:"binary"`
+	Cert           string   `json:"cert"`
+	DisplayVersion bool     `json:"-"`
+	Key            string   `json:"key"`
+	ListProviders  bool     `json:"-"`
+	Port           int      `json:"port,string"`
+	Provider       string   `json:"provider"`
+	ServerMode     bool     `json:"-"`
+	Verbose        bool     `json:"verbose,string"`
+	Whitelist      []string `json:"whitelist"`
 }
 
 // Load reads the configuration from ~/.s/config and loads it into the Config struct.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -85,6 +85,9 @@ func performCommand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	providers.SetBlacklist(config.Blacklist)
+	providers.SetWhitelist(config.Whitelist)
+
 	if config.ListProviders {
 		fmt.Printf(providers.DisplayProviders())
 		return nil

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -16,6 +16,14 @@ const (
 	defaultRegion   = "US"
 )
 
+var (
+	enableBlacklist = false
+	enableWhitelist = false
+
+	blacklist = make(map[string]interface{})
+	whitelist = make(map[string]interface{})
+)
+
 // Provider interface provides a way to build the URI
 // for each provider.
 type Provider interface {
@@ -33,6 +41,28 @@ func init() {
 // This will register the provider so it can be used.
 func AddProvider(name string, provider Provider) {
 	Providers[name] = provider
+}
+
+// SetBlacklist filters out unneeded providers.
+func SetBlacklist(b []string) {
+	for _, v := range b {
+		blacklist[v] = nil
+	}
+
+	if len(blacklist) > 0 {
+		enableBlacklist = true
+	}
+}
+
+// SetWhitelist sets an exact list of supported providers.
+func SetWhitelist(w []string) {
+	for _, v := range w {
+		whitelist[v] = nil
+	}
+
+	if len(whitelist) > 0 {
+		enableWhitelist = true
+	}
 }
 
 // Search builds a search URL and opens it in your browser.
@@ -96,6 +126,20 @@ func ProviderNames() []string {
 	names := []string{}
 
 	for key := range Providers {
+		if enableWhitelist {
+			_, ok := whitelist[key]
+			if !ok {
+				continue
+			}
+		}
+
+		if enableBlacklist {
+			_, ok := blacklist[key]
+			if ok {
+				continue
+			}
+		}
+
 		names = append(names, key)
 	}
 


### PR DESCRIPTION
Provides both a whitelist and blacklist for providers.

Easily include or exclude any providers you want in `~/.s/config`