### PR TITLE
Added support for custom providers in configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ To setup your own default configuration just create `~/.s/config`. The configura
 For more information about UCL visit:
 [https://github.com/vstakhov/libucl](https://github.com/vstakhov/libucl)
 
+The following keys are supported:
+
+* blacklist (array of providers to exclude)
+* binary (binary to launch search URI)
+* cert (path to cert.pem for TLS)
+* customProviders (array of custom providers)
+* key (path to key.pem for TLS)
+* port (server port)
+* provider (search provider)
+* verbose (display URL when opening)
+* whitelist (array of providers to include)
+
 Set your default provider to duckduckgo:
 ```
 provider: duckduckgo
@@ -134,16 +146,20 @@ To exclude providers you don't need:
 blacklist: [dumpert]
 ```
 
-The following keys are supported:
+To add a custom provider:
+```
+customProviders [
+  {
+    name: example
+    url: "http://example.com?q=%s"
+  }
+]
+```
 
-* blacklist (array of providers to exclude)
-* binary (binary to launch search URI)
-* cert (path to cert.pem for TLS)
-* key (path to key.pem for TLS)
-* port (server port)
-* provider (search provider)
-* verbose (display URL when opening)
-* whitelist (array of providers to include)
+Custom providers require a few things:
+* An alphanumeric name. `^[a-zA-Z0-9_]*$`
+* A `%s` token for the query string.
+* A valid url scheme.
 
 ## Supported Providers
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -6,22 +6,24 @@ import (
 	"os/user"
 	"path/filepath"
 
-	ucl "github.com/zquestz/go-ucl"
+	"github.com/zquestz/go-ucl"
+	"github.com/zquestz/s/providers"
 )
 
 // Config stores all the application configuration.
 type Config struct {
-	Blacklist      []string `json:"blacklist"`
-	Binary         string   `json:"binary"`
-	Cert           string   `json:"cert"`
-	DisplayVersion bool     `json:"-"`
-	Key            string   `json:"key"`
-	ListProviders  bool     `json:"-"`
-	Port           int      `json:"port,string"`
-	Provider       string   `json:"provider"`
-	ServerMode     bool     `json:"-"`
-	Verbose        bool     `json:"verbose,string"`
-	Whitelist      []string `json:"whitelist"`
+	Blacklist       []string                    `json:"blacklist"`
+	Binary          string                      `json:"binary"`
+	Cert            string                      `json:"cert"`
+	CustomProviders []*providers.CustomProvider `json:"customProviders"`
+	DisplayVersion  bool                        `json:"-"`
+	Key             string                      `json:"key"`
+	ListProviders   bool                        `json:"-"`
+	Port            int                         `json:"port,string"`
+	Provider        string                      `json:"provider"`
+	ServerMode      bool                        `json:"-"`
+	Verbose         bool                        `json:"verbose,string"`
+	Whitelist       []string                    `json:"whitelist"`
 }
 
 // Load reads the configuration from ~/.s/config and loads it into the Config struct.

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -41,12 +41,26 @@ func init() {
 		bail(fmt.Errorf("Failed to load configuration: %s", err))
 	}
 
+	loadCustomProviders()
+
 	prepareFlags()
 }
 
 func bail(err error) {
 	fmt.Fprintf(os.Stderr, "[Error] %s\n", err)
 	os.Exit(1)
+}
+
+func loadCustomProviders() {
+	for _, p := range config.CustomProviders {
+		err := p.Valid()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[Warn] Invalid provider %q: %s\n", p.Name, err)
+			continue
+		}
+
+		providers.AddProvider(p.Name, p)
+	}
 }
 
 func prepareFlags() {

--- a/providers/custom.go
+++ b/providers/custom.go
@@ -1,0 +1,49 @@
+package providers
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var alphanums = regexp.MustCompile("^[a-zA-Z0-9_]*$")
+
+// CustomProvider is used for Config based providers.
+type CustomProvider struct {
+	Name string `json:"name"`
+	Url  string `json:"url"`
+}
+
+// BuildURI builds the URI for custom providers.
+func (c *CustomProvider) BuildURI(q string) string {
+	return fmt.Sprintf(c.Url, url.QueryEscape(q))
+}
+
+// Valid checks if the custom provider is setup correctly.
+func (c *CustomProvider) Valid() error {
+	// Validate name is only alphanums.
+	if !alphanums.Match([]byte(c.Name)) {
+		return fmt.Errorf("name must be alphanumeric")
+	}
+
+	u, err := url.Parse(c.Url)
+	if err != nil {
+		return err
+	}
+
+	c.Url = u.String()
+
+	// Make sure query token is present
+	hasToken := strings.Contains(c.Url, "%s")
+	if !hasToken {
+		return fmt.Errorf("token %q required", "%s")
+	}
+
+	// Validate scheme is set. Don't limit to http.
+	if u.Scheme == "" {
+		return fmt.Errorf("url scheme required")
+	}
+
+	return nil
+}


### PR DESCRIPTION
You can now create custom providers through `~/.s/config`. The syntax is as follows:

```
customProviders [
  {
    name: example
    url: "http://example.com?q=%s"
  }
]
```