### PR TITLE
fixes for fish completion

### DIFF
--- a/autocomplete/s.fish
+++ b/autocomplete/s.fish
@@ -4,15 +4,16 @@ function __fish_s_needs_option_argument
     if test $cmd[-1] = $opt
         return 0
     else if [ (count $cmd) -ge 2 ]
-        return (test $cmd[-2] = $opt)
-    else
-        return 1
+        if test $cmd[-2] = $opt
+            if not contains $cmd[-1] (s -l)
+                return 0
+            end
+        end
     end
-end
-
-function __fish_s_provider_list
-    s -l
+    return 1
 end
 
 complete -f -c s -s p
-complete -f -c s -n '__fish_s_needs_option_argument -p' -a '(__fish_s_provider_list)'
+complete -f -c s -l provider
+complete -f -c s -n '__fish_s_needs_option_argument -p' -a '(s -l)'
+complete -f -c s -n '__fish_s_needs_option_argument --provider' -a '(s -l)'


### PR DESCRIPTION
- can just embed `s -l` as the options
- fix condition function so it doesn't double-trigger

@bucaran, any idea why i couldn't combine the conditions on 7 and 8 with `-a`?