### PR TITLE
Initial support for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Flags:
   -c, --cert string       path to cert.pem for TLS
   -k, --key string        path to key.pem for TLS
   -l, --list-providers    list supported providers
+      --list-tags         list available tags
       --port int          server port (default 8080)
   -p, --provider string   search provider (default "google")
   -s, --server            launch web server
-  -v, --verbose           display URL when opening
+  -t, --tag string        search tag
+  -v, --verbose           verbose mode
       --version           display version
+
 ```
 
 ## Install
@@ -50,9 +53,14 @@ Search for rhinos on wikipedia
 s -p wikipedia rhinos
 ```
 
-## Provider Expansion
+Search providers tagged "video" for muppets.
+```
+s -t video muppets
+```
 
-We can do partial matching of provider names. This searches Facebook for hamsters.
+## Provider/Tag Expansion
+
+We can do partial matching of provider and tag names. This searches Facebook for hamsters.
 ```
 s -p fa hamsters
 ```
@@ -62,9 +70,19 @@ Or toasters on amazon.
 s -p am toasters
 ```
 
-## Provider Autocompletion
+This searches "tech-news" tagged providers for ssd info.
+```
+s -t te ssd
+```
 
-Autocompletion for providers is supported. For setting up autocompletion:
+Or shopping sites for blankets.
+```
+s -t sh blankets
+```
+
+## Provider/Tag Autocompletion
+
+Autocompletion is supported for providers and tags. To set up autocompletion:
 
 1. Have `s` installed
 2. Add the following lines to `~/.bash_profile` or `~/.zshrc`
@@ -144,7 +162,8 @@ The following keys are supported:
 * key (path to key.pem for TLS)
 * port (server port)
 * provider (search provider)
-* verbose (display URL when opening)
+* tag (search tag)
+* verbose (verbose mode)
 * whitelist (array of providers to include)
 
 Set your default provider to duckduckgo:
@@ -168,6 +187,7 @@ customProviders [
   {
     name: example
     url: "http://example.com?q=%s"
+    tags: [example]
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Custom providers require a few things:
 * lmgtfy
 * macports
 * mdn
+* medium
 * metacpan
 * msdn
 * naver

--- a/autocomplete/s-completion.bash
+++ b/autocomplete/s-completion.bash
@@ -20,7 +20,7 @@ _provider_completion()
 {
     local cur=${COMP_WORDS[COMP_CWORD]}
     local prev=${COMP_WORDS[COMP_CWORD-1]}
-    local longOpts="--binary --cert --help --key --list-providers --port --provider --server --verbose --version"
+    local longOpts="--binary --cert --help --key --list-providers --list-tags --port --provider --server --tags --verbose --version"
 
     # _filedir (in newer bash completions) is a huge improvement on compgen -f or compgen -G
     # because it deals correctly with spaces, ~ expansion, and .inputrc preferences.
@@ -28,7 +28,7 @@ _provider_completion()
     comp_path () { if type _filedir >/dev/null; then _filedir ; else comp -G $cur\* ; fi; }
 
     case "$cur" in
-        -) comp -W "-b -c -k -h -k -l -p -s -v" && return 0 ;;
+        -) comp -W "-b -c -k -h -k -l -p -s -t -v" && return 0 ;;
        -*) comp -W "$longOpts" && return 0 ;;
     esac
 
@@ -36,6 +36,7 @@ _provider_completion()
     # isn't an option which expects an argument
     case "$prev" in
                        -p|--provider) comp -W "$(s --list-providers)" ;;
+                            -t|--tag) comp -W "$(s --list-tags)" ;;
       -c|--cert|-k|--key|-b|--binary) comp_path ;;
                                    *) [[ -z "$cur" ]] && comp -W "$longOpts" ;;
     esac

--- a/autocomplete/s.fish
+++ b/autocomplete/s.fish
@@ -59,9 +59,11 @@ complete -f -c s -o b -l binary         -d 'binary to launch search URI'
 complete -f -c s -o c -l cert           -d 'path to cert.pem for TLS'
 complete -f -c s -o k -l key            -d 'path to key.pem for TLS'
 complete -f -c s -o l -l list-providers -d 'list supported providers'
+complete -f -c s      -l list-tags      -d 'list available tags'
 complete -f -c s      -l port           -d 'server port (default 8080)'
 complete -f -c s -o p -l provider       -d 'search provider (default "google")'
 complete -f -c s -o s -l server         -d 'launch web server'
+complete -f -c s -o t -l tags           -d 'search tags'
 complete -f -c s -o v -l verbose        -d 'display URL when opening'
 complete -f -c s      -l version        -d 'display version'
 
@@ -80,3 +82,7 @@ complete -c s -n '__fish_s_needs_option_argument --key' -a '(__fish_s_find_pem_f
 # s {-p|--provider} options
 complete -f -c s -n '__fish_s_needs_option_argument -p' -a '(s -l)'
 complete -f -c s -n '__fish_s_needs_option_argument --provider' -a '(s -l)'
+
+# s {-t|--tag} options
+complete -f -c s -n '__fish_s_needs_option_argument -t' -a '(s --list-tags)'
+complete -f -c s -n '__fish_s_needs_option_argument --tags' -a '(s --list-tags)'

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -19,9 +19,11 @@ type Config struct {
 	DisplayVersion  bool                        `json:"-"`
 	Key             string                      `json:"key"`
 	ListProviders   bool                        `json:"-"`
+	ListTags        bool                        `json:"-"`
 	Port            int                         `json:"port,string"`
 	Provider        string                      `json:"provider"`
 	ServerMode      bool                        `json:"-"`
+	Tag             string                      `json:"tag"`
 	Verbose         bool                        `json:"verbose,string"`
 	Whitelist       []string                    `json:"whitelist"`
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -75,11 +75,15 @@ func prepareFlags() {
 	SearchCmd.PersistentFlags().BoolVarP(
 		&config.DisplayVersion, "version", "", false, "display version")
 	SearchCmd.PersistentFlags().BoolVarP(
-		&config.Verbose, "verbose", "v", config.Verbose, "display URL when opening")
+		&config.Verbose, "verbose", "v", config.Verbose, "verbose mode")
 	SearchCmd.PersistentFlags().StringVarP(
 		&config.Provider, "provider", "p", config.Provider, "search provider")
+	SearchCmd.PersistentFlags().StringVarP(
+		&config.Tag, "tag", "t", config.Tag, "search tag")
 	SearchCmd.PersistentFlags().BoolVarP(
 		&config.ListProviders, "list-providers", "l", false, "list supported providers")
+	SearchCmd.PersistentFlags().BoolVarP(
+		&config.ListTags, "list-tags", "", false, "list available tags")
 	SearchCmd.PersistentFlags().StringVarP(
 		&config.Binary, "binary", "b", config.Binary, "binary to launch search URI")
 	SearchCmd.PersistentFlags().BoolVarP(
@@ -103,7 +107,12 @@ func performCommand(cmd *cobra.Command, args []string) error {
 	providers.SetWhitelist(config.Whitelist)
 
 	if config.ListProviders {
-		fmt.Printf(providers.DisplayProviders())
+		fmt.Printf(providers.DisplayProviders(config.Verbose))
+		return nil
+	}
+
+	if config.ListTags {
+		fmt.Printf(providers.DisplayTags(config.Verbose))
 		return nil
 	}
 
@@ -136,7 +145,14 @@ func performCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if query != "" {
-		err := providers.Search(config.Binary, config.Provider, query, config.Verbose)
+		err := providers.Search(
+			config.Binary,
+			config.Provider,
+			config.Tag,
+			query,
+			cmd.Flags().Changed("provider"),
+			config.Verbose,
+		)
 		if err != nil {
 			return err
 		}

--- a/providers/500px/500px.go
+++ b/providers/500px/500px.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://500px.com/search?q=%s&type=photos", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"photos"}
+}

--- a/providers/8tracks/8tracks.go
+++ b/providers/8tracks/8tracks.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://8tracks.com/explore/%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"music"}
+}

--- a/providers/amazon/amazon.go
+++ b/providers/amazon/amazon.go
@@ -45,3 +45,8 @@ func (p *Provider) BuildURI(q string) string {
 		return fmt.Sprintf("https://www.amazon.com/s/?keywords=%s", url.QueryEscape(q))
 	}
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"shopping"}
+}

--- a/providers/archpkg/archpkg.go
+++ b/providers/archpkg/archpkg.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.archlinux.org/packages/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"arch"}
+}

--- a/providers/archwiki/archwiki.go
+++ b/providers/archwiki/archwiki.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://wiki.archlinux.org/index.php?search=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"arch"}
+}

--- a/providers/arstechnica/arstechnica.go
+++ b/providers/arstechnica/arstechnica.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://arstechnica.com/search/?ie=UTF-8&q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"tech-news"}
+}

--- a/providers/arxiv/arxiv.go
+++ b/providers/arxiv/arxiv.go
@@ -49,3 +49,8 @@ func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://arxiv.org/find/all/1/all:+%s/0/1/0/all/0/1",
 		url.QueryEscape(formatWithOp(results, "OR")))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"education"}
+}

--- a/providers/atmospherejs/atmospherejs.go
+++ b/providers/atmospherejs/atmospherejs.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://atmospherejs.com/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"javascript"}
+}

--- a/providers/aur/aur.go
+++ b/providers/aur/aur.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://aur.archlinux.org/packages/?K=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"arch"}
+}

--- a/providers/baidu/baidu.go
+++ b/providers/baidu/baidu.go
@@ -18,3 +18,13 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.baidu.com/s?wd=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	switch providers.Language() {
+	case "zh":
+		return []string{"search"}
+	default:
+		return []string{}
+	}
+}

--- a/providers/bandcamp/bandcamp.go
+++ b/providers/bandcamp/bandcamp.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://bandcamp.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"music"}
+}

--- a/providers/bgr/bgr.go
+++ b/providers/bgr/bgr.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://bgr.com/?s=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"tech-news"}
+}

--- a/providers/bing/bing.go
+++ b/providers/bing/bing.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.bing.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"search"}
+}

--- a/providers/buzzfeed/buzzfeed.go
+++ b/providers/buzzfeed/buzzfeed.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.buzzfeed.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/cnn/cnn.go
+++ b/providers/cnn/cnn.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.cnn.com/search/?text=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"news"}
+}

--- a/providers/codepen/codepen.go
+++ b/providers/codepen/codepen.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://codepen.io/search/pens?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/coursera/coursera.go
+++ b/providers/coursera/coursera.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.coursera.org/courses/?query=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"education"}
+}

--- a/providers/cplusplus/cplusplus.go
+++ b/providers/cplusplus/cplusplus.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.cplusplus.com/search.do?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/crunchyroll/crunchyroll.go
+++ b/providers/crunchyroll/crunchyroll.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.crunchyroll.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"movies"}
+}

--- a/providers/custom.go
+++ b/providers/custom.go
@@ -11,13 +11,19 @@ var alphanums = regexp.MustCompile("^[a-zA-Z0-9_]*$")
 
 // CustomProvider is used for Config based providers.
 type CustomProvider struct {
-	Name string `json:"name"`
-	URL  string `json:"url"`
+	Name    string   `json:"name"`
+	URL     string   `json:"url"`
+	TagList []string `json:"tags"`
 }
 
 // BuildURI builds the URI for custom providers.
 func (c *CustomProvider) BuildURI(q string) string {
 	return fmt.Sprintf(c.URL, url.QueryEscape(q))
+}
+
+// Tags returns the tags relevant to this provider.
+func (c *CustomProvider) Tags() []string {
+	return c.TagList
 }
 
 // Valid checks if the custom provider is setup correctly.

--- a/providers/debianpkg/debianpkg.go
+++ b/providers/debianpkg/debianpkg.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://packages.debian.org/search?keywords=%s&searchon=names&suite=stable&section=all", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/digg/digg.go
+++ b/providers/digg/digg.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://digg.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/diigo/diigo.go
+++ b/providers/diigo/diigo.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.diigo.com/search?what=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/dockerhub/dockerhub.go
+++ b/providers/dockerhub/dockerhub.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://hub.docker.com/search/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/dribbble/dribbble.go
+++ b/providers/dribbble/dribbble.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://dribbble.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"pics"}
+}

--- a/providers/duckduckgo/duckduckgo.go
+++ b/providers/duckduckgo/duckduckgo.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://duckduckgo.com/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"search"}
+}

--- a/providers/dumpert/dumpert.go
+++ b/providers/dumpert/dumpert.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.dumpert.nl/search/ALL/%s/", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/engadget/engadget.go
+++ b/providers/engadget/engadget.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.engadget.com/search/?search-terms=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"tech-news"}
+}

--- a/providers/facebook/facebook.go
+++ b/providers/facebook/facebook.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.facebook.com/search/top/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"social"}
+}

--- a/providers/flickr/flickr.go
+++ b/providers/flickr/flickr.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.flickr.com/search/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"photos", "pics"}
+}

--- a/providers/flipkart/flipkart.go
+++ b/providers/flipkart/flipkart.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.flipkart.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/foursquare/foursquare.go
+++ b/providers/foursquare/foursquare.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://foursquare.com/explore?&q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/gist/gist.go
+++ b/providers/gist/gist.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://gist.github.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"code"}
+}

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://github.com/search?utf8=✓&q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"code"}
+}

--- a/providers/gmail/gmail.go
+++ b/providers/gmail/gmail.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://mail.google.com/mail/u/0/#search/%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/go/go.go
+++ b/providers/go/go.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://golang.org/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"go"}
+}

--- a/providers/godoc/godoc.go
+++ b/providers/godoc/godoc.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://godoc.org/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"go"}
+}

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.google.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"search"}
+}

--- a/providers/googledocs/googledocs.go
+++ b/providers/googledocs/googledocs.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://docs.google.com/document/u/0/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/googleplus/googleplus.go
+++ b/providers/googleplus/googleplus.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://plus.google.com/s/%s/top", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"social"}
+}

--- a/providers/hackernews/hackernews.go
+++ b/providers/hackernews/hackernews.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://hn.algolia.com/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"tech-news"}
+}

--- a/providers/ietf/ietf.go
+++ b/providers/ietf/ietf.go
@@ -19,3 +19,8 @@ func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://datatracker.ietf.org/doc/search/"+
 		"?name=%s&rfcs=on&activedrafts=on", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/ifttt/ifttt.go
+++ b/providers/ifttt/ifttt.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.ifttt.com/recipes/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/imdb/imdb.go
+++ b/providers/imdb/imdb.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.imdb.com/find?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"movies"}
+}

--- a/providers/imgur/imgur.go
+++ b/providers/imgur/imgur.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://imgur.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"pics"}
+}

--- a/providers/inbox/inbox.go
+++ b/providers/inbox/inbox.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://inbox.google.com/search/%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/instagram/instagram.go
+++ b/providers/instagram/instagram.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.instagram.com/explore/tags/%s/", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"photos", "pics"}
+}

--- a/providers/kickasstorrents/kickasstorrents.go
+++ b/providers/kickasstorrents/kickasstorrents.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://kat.cr/usearch/%s/", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"torrents"}
+}

--- a/providers/libgen/libgen.go
+++ b/providers/libgen/libgen.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://gen.lib.rus.ec/search.php?req=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"education"}
+}

--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -20,3 +20,8 @@ func (p *Provider) BuildURI(q string) string {
 		"https://www.linkedin.com/vsearch/f?type=all&keywords=%s&search=Search",
 		url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/lmgtfy/lmgtfy.go
+++ b/providers/lmgtfy/lmgtfy.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://lmgtfy.com/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/macports/macports.go
+++ b/providers/macports/macports.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.macports.org/ports.php?by=name&substr=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/mdn/mdn.go
+++ b/providers/mdn/mdn.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://developer.mozilla.org/en-US/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/medium/medium.go
+++ b/providers/medium/medium.go
@@ -1,0 +1,25 @@
+package medium
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/zquestz/s/providers"
+)
+
+func init() {
+	providers.AddProvider("medium", &Provider{})
+}
+
+// Provider merely implements the Provider interface.
+type Provider struct{}
+
+// BuildURI generates a search URL for Medium.
+func (p *Provider) BuildURI(q string) string {
+	return fmt.Sprintf("https://medium.com/search?q=%s", url.QueryEscape(q))
+}
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/metacpan/metacpan.go
+++ b/providers/metacpan/metacpan.go
@@ -19,3 +19,8 @@ type Provider struct {
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://metacpan.org/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/msdn/msdn.go
+++ b/providers/msdn/msdn.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://social.msdn.microsoft.com/Search/en-US?query=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/naver/naver.go
+++ b/providers/naver/naver.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://search.naver.com/search.naver?query=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/netflix/netflix.go
+++ b/providers/netflix/netflix.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.netflix.com/search/%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"movies"}
+}

--- a/providers/nhaccuatui/nhaccuatui.go
+++ b/providers/nhaccuatui/nhaccuatui.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.nhaccuatui.com/tim-kiem?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/npm/npm.go
+++ b/providers/npm/npm.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.npmjs.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"javascript"}
+}

--- a/providers/npmsearch/npmsearch.go
+++ b/providers/npmsearch/npmsearch.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://npmsearch.com/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"javascript"}
+}

--- a/providers/npr/npr.go
+++ b/providers/npr/npr.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.npr.org/templates/search/index.php?searchinput=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"news"}
+}

--- a/providers/nvd/nvd.go
+++ b/providers/nvd/nvd.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://web.nvd.nist.gov/view/vuln/search-results?query=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/overstock/overstock.go
+++ b/providers/overstock/overstock.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.overstock.com/search?keywords=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"shopping"}
+}

--- a/providers/packagist/packagist.go
+++ b/providers/packagist/packagist.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://packagist.org/search/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/phandroid/phandroid.go
+++ b/providers/phandroid/phandroid.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://phandroid.com/gsearch/?search_term=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/php/php.go
+++ b/providers/php/php.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://php.net/%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/pinterest/pinterest.go
+++ b/providers/pinterest/pinterest.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.pinterest.com/search/pins/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/python/python.go
+++ b/providers/python/python.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.python.org/search/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/quora/quora.go
+++ b/providers/quora/quora.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.quora.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"forums"}
+}

--- a/providers/reddit/reddit.go
+++ b/providers/reddit/reddit.go
@@ -27,3 +27,8 @@ func (p *Provider) BuildURI(q string) string {
 	}
 	return fmt.Sprintf("https://www.reddit.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"forums"}
+}

--- a/providers/rottentomatoes/rottentomatoes.go
+++ b/providers/rottentomatoes/rottentomatoes.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://www.rottentomatoes.com/search/?search=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"movies"}
+}

--- a/providers/rubygems/rubygems.go
+++ b/providers/rubygems/rubygems.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://rubygems.org/search?utf8=✓&query=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/soundcloud/soundcloud.go
+++ b/providers/soundcloud/soundcloud.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://soundcloud.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"music"}
+}

--- a/providers/spotify/spotify.go
+++ b/providers/spotify/spotify.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://play.spotify.com/search/%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"music"}
+}

--- a/providers/stackoverflow/stackoverflow.go
+++ b/providers/stackoverflow/stackoverflow.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://stackoverflow.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"code"}
+}

--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://store.steampowered.com/search/?term=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/taobao/taobao.go
+++ b/providers/taobao/taobao.go
@@ -16,5 +16,15 @@ type Provider struct{}
 
 // BuildURI generates a search URL for Taobao.
 func (p *Provider) BuildURI(q string) string {
-	return fmt.Sprintf("https://s.taobao.com/search?q=%s", url.QueryEscape(q))
+	return fmt.Sprintf("https://world.taobao.com/search/search.htm?_input_charset=utf-8&q=%s", url.QueryEscape(q))
+}
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	switch providers.Language() {
+	case "zh":
+		return []string{"shopping"}
+	default:
+		return []string{}
+	}
 }

--- a/providers/thepiratebay/thepiratebay.go
+++ b/providers/thepiratebay/thepiratebay.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://thepiratebay.se/search/%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"torrents"}
+}

--- a/providers/theregister/theregister.go
+++ b/providers/theregister/theregister.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("http://search.theregister.co.uk/?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"news"}
+}

--- a/providers/torrentz/torrentz.go
+++ b/providers/torrentz/torrentz.go
@@ -19,3 +19,8 @@ type Provider struct {
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.torrentz.eu/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"torrents"}
+}

--- a/providers/twitchtv/twitchtv.go
+++ b/providers/twitchtv/twitchtv.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.twitch.tv/search?query=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/twitter/twitter.go
+++ b/providers/twitter/twitter.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://twitter.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"social"}
+}

--- a/providers/unity3d/unity3d.go
+++ b/providers/unity3d/unity3d.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://unity3d.com/search?gq=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/upcloud/upcloud.go
+++ b/providers/upcloud/upcloud.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.upcloud.com/support/?s=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/vimeo/vimeo.go
+++ b/providers/vimeo/vimeo.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://vimeo.com/search?q=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"video"}
+}

--- a/providers/wikipedia/wikipedia.go
+++ b/providers/wikipedia/wikipedia.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://en.wikipedia.org/wiki/Special:Search?search=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"education"}
+}

--- a/providers/wolframalpha/wolframalpha.go
+++ b/providers/wolframalpha/wolframalpha.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.wolframalpha.com/input/?i=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{}
+}

--- a/providers/yahoo/yahoo.go
+++ b/providers/yahoo/yahoo.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://search.yahoo.com/search?p=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"search"}
+}

--- a/providers/yandex/yandex.go
+++ b/providers/yandex/yandex.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.yandex.com/search/?text=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"search"}
+}

--- a/providers/youtube/youtube.go
+++ b/providers/youtube/youtube.go
@@ -18,3 +18,8 @@ type Provider struct{}
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf("https://www.youtube.com/results?search_query=%s", url.QueryEscape(q))
 }
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"video"}
+}

--- a/s.go
+++ b/s.go
@@ -57,6 +57,7 @@ import (
 	_ "github.com/zquestz/s/providers/lmgtfy"
 	_ "github.com/zquestz/s/providers/macports"
 	_ "github.com/zquestz/s/providers/mdn"
+	_ "github.com/zquestz/s/providers/medium"
 	_ "github.com/zquestz/s/providers/metacpan"
 	_ "github.com/zquestz/s/providers/msdn"
 	_ "github.com/zquestz/s/providers/naver"

--- a/server/index.go
+++ b/server/index.go
@@ -37,7 +37,7 @@ func index(defaultProvider string, w http.ResponseWriter, r *http.Request) {
 		CSS:         IndexCSS,
 		JS:          IndexJS,
 		Placeholder: "kittens...",
-		Providers:   providers.ProviderNames(),
+		Providers:   providers.ProviderNames(false),
 	}
 
 	t.Execute(w, tvars)


### PR DESCRIPTION
I have added Tags() to the provider interface so you can easily launch multiple searches at the same time. Figured it is useful when trying to search for movies, news, etc.

- [x] Updated all auto complete scripts to include the new flags.
- [x] Supports searching a tag and a specific provider. Useful if you want to search a tag, but also google.
- [x] Supports adding tags to custom providers. Just add "tags" to your config.
- [x] Added `--list-tags` flag to display all available tags.
- [x] Added Tags() method to all providers.
- [x] Updated README.md
- [x] Added support for tag expansion.
- [x] Populate all providers with an initial set of tags.
- [x] Update -v flag to support list views.