### PR TITLE
Updated make uninstall to support multiple GOPATH's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,5 @@ install: all
 	go install .
 
 uninstall:
-	rm $(GOPATH)/bin/$(APPNAME)
+	@rm $${GOPATH%%:*}/bin/$(APPNAME)
+	@echo rm $${GOPATH%%:*}/bin/$(APPNAME)


### PR DESCRIPTION
Allow `make uninstall` to function when multiple GOPATH's are set. It just defaults to using the first one.

Tested in bash, zsh, and fish shell.

Fixes https://github.com/zquestz/s/issues/105

@mewmew thanks for the report.