### PR TITLE
Tag support for server mode.

### DIFF
--- a/providers/8tracks/8tracks.go
+++ b/providers/8tracks/8tracks.go
@@ -16,7 +16,7 @@ type Provider struct{}
 
 // BuildURI generates a search URL for 8tracks.
 func (p *Provider) BuildURI(q string) string {
-	return fmt.Sprintf("https://8tracks.com/explore/%s", url.QueryEscape(q))
+	return fmt.Sprintf("https://8tracks.com/search?q=%s", url.QueryEscape(q))
 }
 
 // Tags returns the tags relevant to this provider.

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -85,7 +85,8 @@ func Search(binary string, p string, t string, q string, userProvider bool, verb
 			return err
 		}
 
-		for _, provider := range Providers {
+		for _, providerName := range ProviderNames(false) {
+			provider := Providers[providerName]
 			for _, providerTag := range provider.Tags() {
 				if providerTag == tag {
 					builders = append(builders, provider)

--- a/server/index.go
+++ b/server/index.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"text/template"
 
@@ -12,6 +13,7 @@ type templateVars struct {
 	JS          string
 	Placeholder string
 	Providers   []string
+	Tags        []string
 }
 
 func index(defaultProvider string, w http.ResponseWriter, r *http.Request) {
@@ -27,17 +29,33 @@ func index(defaultProvider string, w http.ResponseWriter, r *http.Request) {
 		return ""
 	}
 
+	label := func(opt string) string {
+		if opt == "" {
+			return fmt.Sprintf(" label=%q", "-")
+		}
+
+		return ""
+	}
+
 	t.Funcs(template.FuncMap{
 		"Selected": selected,
+		"Label":    label,
 	})
 
-	t, _ = t.Parse(IndexTemplate)
+	t, _ = t.Parse(indexTemplate)
+
+	providerList := []string{""}
+	providerList = append(providerList, providers.ProviderNames(false)...)
+
+	tagList := []string{""}
+	tagList = append(tagList, providers.TagNames(false)...)
 
 	tvars := templateVars{
-		CSS:         IndexCSS,
-		JS:          IndexJS,
+		CSS:         indexCSS,
+		JS:          indexJS(defaultProvider),
 		Placeholder: "kittens...",
-		Providers:   providers.ProviderNames(false),
+		Providers:   providerList,
+		Tags:        tagList,
 	}
 
 	t.Execute(w, tvars)


### PR DESCRIPTION
Adds meta search to the web interface. Opens a tab for each tagged provider. The provider only search still uses a redirect, whereas the tag based search leaves a tab for s.

Also noticed 8tracks search was a bit off when testing the "music" tag. 

@akb @mbhinder @KeizerDev @tw4dl 