### PR TITLE
Fix URL parsing for custom providers

### DIFF
--- a/providers/custom.go
+++ b/providers/custom.go
@@ -33,17 +33,15 @@ func (c *CustomProvider) Valid() error {
 		return fmt.Errorf("name must be alphanumeric")
 	}
 
-	u, err := url.Parse(c.URL)
-	if err != nil {
-		return err
-	}
-
-	c.URL = u.String()
-
 	// Make sure query token is present
 	hasToken := strings.Contains(c.URL, "%s")
 	if !hasToken {
 		return fmt.Errorf("token %q required", "%s")
+	}
+
+	u, err := url.Parse(fmt.Sprintf(c.URL, "placeholder"))
+	if err != nil {
+		return err
 	}
 
 	// Validate scheme is set. Don't limit to http.

--- a/providers/custom_test.go
+++ b/providers/custom_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 var (
 	validName = "example"
-	validURL  = "http://example.com/?q=%s"
+	validURL  = "http://example.com/%s"
 )
 
 // TestValid checks validation errors on custom providers.


### PR DESCRIPTION
url.Parse() fails if the path (instead of the query string) contains %s.
This adds support for provider urls like "https://<group>.slack.com/messages/general/search/%s/".