### PR TITLE
Update configuration path to .config/s

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Feel free to try it out at [https://jumps.io/](https://jumps.io/).
 
 ## Configuration
 
-To setup your own default configuration just create `~/.s/config`. The configuration file is in UCL format. JSON is also fully supported as UCL can parse JSON files.
+To setup your own default configuration just create `~/.config/s/config`. The configuration file is in UCL format. JSON is also fully supported as UCL can parse JSON files.
 
 For more information about UCL visit:
 [https://github.com/vstakhov/libucl](https://github.com/vstakhov/libucl)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,7 +29,8 @@ type Config struct {
 	Whitelist       []string                    `json:"whitelist"`
 }
 
-// Load reads the configuration from ~/.s/config and loads it into the Config struct.
+// Load reads the configuration from ~/.config/s/config
+// and loads it into the Config struct.
 // The config is in UCL format.
 func (c *Config) Load() error {
 	conf, err := c.loadConfig()
@@ -54,13 +55,21 @@ func (c *Config) loadConfig() ([]byte, error) {
 		return nil, err
 	}
 
-	f, err := os.Open(filepath.Join(h, ".s", "config"))
+	f, err := os.Open(filepath.Join(h, ".config", "s", "config"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
-		}
+			// Legacy configuration path.
+			f, err = os.Open(filepath.Join(h, ".s", "config"))
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil, nil
+				}
 
-		return nil, err
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 	defer f.Close()
 


### PR DESCRIPTION
Updates configuration file lookup to `.config/s/config`. If it isn't found then it looks at the old location of `.s/config`.

@vthiery @cyrilgdn

Fixes https://github.com/zquestz/s/issues/129