### PR TITLE
Add snapcraft support for building snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,3 +21,5 @@ apps:
     command: s
     plugs:
       - desktop
+      - network
+      - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: ws
+name: s-search
 base: core18 # the base snap is the execution environment for this snap
 version:  git
 summary: Open a web search in your terminal. 
@@ -17,7 +17,7 @@ parts:
       - gcc
 
 apps:
-  ws:
+  s-search:
     command: s
     plugs:
       - desktop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: s
+name: ws
 base: core18 # the base snap is the execution environment for this snap
 version:  git
 summary: Open a web search in your terminal. 
@@ -17,7 +17,7 @@ parts:
       - gcc
 
 apps:
-  s:
+  ws:
     command: s
     plugs:
       - desktop

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: s
+base: core18 # the base snap is the execution environment for this snap
+version:  git
+summary: Open a web search in your terminal. 
+description: |
+  Web search from the terminal. Just opens in your browser.
+
+grade: stable
+confinement: strict
+
+parts:
+  s:
+    plugin: go
+    source: .
+    go-importpath: github.com/zquestz/s
+    build-packages:
+      - gcc
+
+apps:
+  s:
+    command: s
+    plugs:
+      - desktop


### PR DESCRIPTION
I recently discovered s and as a Google search God (according to my mum) and committed keyboard warrior in the terminal, I love it. Thanks for making it. <3 

I created a snap package of s so it can be featured in the [Snap Store](https://snapcraft.io/store), which is a cross-distribution app-store for Linux. The store has a minimum snap name length of 2, which made snapping ‘s’ a challenge ;). I named it ‘ws’ (web search) which seems appropriate, but that can be modified. That does mean internally the application calls itself ‘s’ (in command line help for example) but externally it’s called ‘ws’.

A single snap (built for many architectures) in the Snap Store will be installable on numerous popular Linux distributions with no changes. It’ll also be discoverable via the [Snap Store](https://snapcraft.io/store), where releases are under your control.

If you're willing to publish this under the ws project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the ws name](https://snapcraft.io/register-snap).

A snap file created by snapcraft (our free software tool for building snaps) can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of s, and push them to the store automatically. Alternatively it’s possible to integrate publishing the snap via your existing travis CI / release process.

I appreciate you may not be aware of snaps and snapcraft, and I’d of course be happy to answer any questions you may have. 
