### PR TITLE
Correct LinkedIn provider search URL

### DIFF
--- a/providers/linkedin/linkedin.go
+++ b/providers/linkedin/linkedin.go
@@ -17,7 +17,7 @@ type Provider struct{}
 // BuildURI generates a search URL for Linkedin.
 func (p *Provider) BuildURI(q string) string {
 	return fmt.Sprintf(
-		"https://www.linkedin.com/vsearch/f?type=all&keywords=%s&search=Search",
+		"https://www.linkedin.com/search/results/all/?keywords=%s",
 		url.QueryEscape(q))
 }
 


### PR DESCRIPTION
The /vsearch URL is 404'ing, this corrects it to the right path.