### PR TITLE
Add kagi provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Custom providers require a few things:
 * imgur
 * inbox
 * instagram
+* kagi
 * kaufda
 * kickasstorrents
 * libgen

--- a/providers/kagi/kagi.go
+++ b/providers/kagi/kagi.go
@@ -1,0 +1,25 @@
+package kagi
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/zquestz/s/providers"
+)
+
+func init() {
+	providers.AddProvider("kagi", &Provider{})
+}
+
+// Provider merely implements the Provider interface.
+type Provider struct{}
+
+// BuildURI generates a search URL for Kagi.
+func (p *Provider) BuildURI(q string) string {
+	return fmt.Sprintf("https://kagi.com/search?q=%s", url.QueryEscape(q))
+}
+
+// Tags returns the tags relevant to this provider.
+func (p *Provider) Tags() []string {
+	return []string{"search"}
+}

--- a/s.go
+++ b/s.go
@@ -68,6 +68,7 @@ import (
 	_ "github.com/zquestz/s/providers/imgur"
 	_ "github.com/zquestz/s/providers/inbox"
 	_ "github.com/zquestz/s/providers/instagram"
+	_ "github.com/zquestz/s/providers/kagi"
 	_ "github.com/zquestz/s/providers/kaufda"
 	_ "github.com/zquestz/s/providers/kickasstorrents"
 	_ "github.com/zquestz/s/providers/libgen"


### PR DESCRIPTION
Add [Kagi](https://kagi.com/) (web search engine) provider.