### PR TITLE
Add "games" tag to game-related search engines

### DIFF
--- a/providers/steam/steam.go
+++ b/providers/steam/steam.go
@@ -21,5 +21,5 @@ func (p *Provider) BuildURI(q string) string {
 
 // Tags returns the tags relevant to this provider.
 func (p *Provider) Tags() []string {
-	return []string{}
+	return []string{"games"}
 }

--- a/providers/twitchtv/twitchtv.go
+++ b/providers/twitchtv/twitchtv.go
@@ -21,5 +21,5 @@ func (p *Provider) BuildURI(q string) string {
 
 // Tags returns the tags relevant to this provider.
 func (p *Provider) Tags() []string {
-	return []string{}
+	return []string{"games"}
 }

--- a/providers/unity3d/unity3d.go
+++ b/providers/unity3d/unity3d.go
@@ -21,5 +21,5 @@ func (p *Provider) BuildURI(q string) string {
 
 // Tags returns the tags relevant to this provider.
 func (p *Provider) Tags() []string {
-	return []string{"games"}
+	return []string{}
 }

--- a/providers/unity3d/unity3d.go
+++ b/providers/unity3d/unity3d.go
@@ -21,5 +21,5 @@ func (p *Provider) BuildURI(q string) string {
 
 // Tags returns the tags relevant to this provider.
 func (p *Provider) Tags() []string {
-	return []string{}
+	return []string{"games"}
 }


### PR DESCRIPTION
## Description

- Tag "steam" provider with "games"
- Tag "twitchtv" provider with "games"
- Tag "unity3d" provider with "games"

I did not see any other existing providers that return content that is exclusively game related.

Based on some limited local testing I feel like "unity3d" is probably out of place here, but I included it so you can make the call. If you agree I will revert that one, or you can feel free to make changes to my PR.

## Checklist

- [x] All files have been linted with gofmt.
- [x] Documentation has been updated.
- [x] All tests pass.
